### PR TITLE
fix: correct Network Commons License link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,7 +1,7 @@
 # Vegas Open Network (VONet)
 
 VONet is a nonprofit project building a **fair, accessible, and community-owned internet** across Las Vegas.  
-Inspired by [NYC Mesh](https://nycmesh.net) and guided by the [Network Commons License](https://vonet.org),  
+Inspired by [NYC Mesh](https://nycmesh.net) and guided by the [Network Commons License](https://networkcommons.org/ncl/),
 we run an open network that anyone can join.
 
 We develop the code, tools, and docs that keep the network running and growing.


### PR DESCRIPTION
## Summary
- fix Network Commons License link in profile README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5492faa18832da8cbeadd63774d1b